### PR TITLE
Add Jekyll to list of examples & add parkr's generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,10 @@ You can find examples of changelogs in the wild in the following projects:
 - [swiftenv](https://github.com/kylef/swiftenv/blob/master/CHANGELOG.md)
 - [CocoaPods](https://github.com/CocoaPods/CocoaPods/blob/master/CHANGELOG.md)
 - [Xcodeproj](https://github.com/CocoaPods/Xcodeproj/blob/master/CHANGELOG.md)
+- [Jekyll](https://github.com/jekyll/jekyll/blob/master/History.markdown)
+
+### Parsers & Generators
+
+Interested in programmatically reading or manipulating your changelog?
+
+- [Golang: parkr/changelog](https://github.com/parkr/changelog)


### PR DESCRIPTION
Hey, @kylef!

Neat project. I use this format religiously! I wrote a generator for it so that [a bot could update the changelog based on a PR merge](https://github.com/jekyll/jekyll/commit/9368e261cc7eb4bf5d23b7f15371e132b5c7c1be).

Here, I propose adding Jekyll to the examples and adding a new section for parsers & generators which can read in a changelog and provide a programmatic interfact to handling the changelog hierarchy.
